### PR TITLE
Consistency fix: TagStyle -> TagType

### DIFF
--- a/webapp/lib/controller.dart
+++ b/webapp/lib/controller.dart
@@ -183,23 +183,23 @@ enum TagOperation {
   REMOVE
 }
 
-void _addTag(String tag, model.TagStyle tagStyle, Map<String, model.TagStyle> tagCollection, [bool isEditable = false]) {
-  tagCollection.addAll({tag: tagStyle});
+void _addTag(String tag, model.TagType tagType, Map<String, model.TagType> tagCollection, [bool isEditable = false]) {
+  tagCollection.addAll({tag: tagType});
   if (!isEditable) model.packageConfigurationData[selectedPackage].availableTags.remove(tag);
 }
 
-void _updateTag(String originalTag, String updatedTag, Map<String, model.TagStyle> tagCollection) {
+void _updateTag(String originalTag, String updatedTag, Map<String, model.TagType> tagCollection) {
   if (originalTag == updatedTag) return;
   var tagKeys = tagCollection.keys.toList();
   var tagValues= tagCollection.values.toList();
   var originalIndex = tagKeys.indexOf(originalTag);
   if (originalIndex < 0) {
-    _addTag(updatedTag, model.TagStyle.Normal, tagCollection);
+    _addTag(updatedTag, model.TagType.Normal, tagCollection);
     return;
   }
   tagKeys.removeAt(originalIndex);
   tagKeys.insert(originalIndex, updatedTag);
-  Map<String, model.TagStyle> updatedTagCollection = {};
+  Map<String, model.TagType> updatedTagCollection = {};
   for (int i = 0; i < tagKeys.length; i++) {
     updatedTagCollection[tagKeys[i]] = tagValues[i];
   }
@@ -207,63 +207,63 @@ void _updateTag(String originalTag, String updatedTag, Map<String, model.TagStyl
   tagCollection.addAll(updatedTagCollection);
 }
 
-void _removeTag(String tag, model.TagStyle tagStyle, Map<String, model.TagStyle> tagCollection, [bool isEditable = false]) {
+void _removeTag(String tag, model.TagType tagType, Map<String, model.TagType> tagCollection, [bool isEditable = false]) {
   tagCollection.remove(tag);
-  if (!isEditable) model.packageConfigurationData[selectedPackage].availableTags.addAll({tag : tagStyle});
+  if (!isEditable) model.packageConfigurationData[selectedPackage].availableTags.addAll({tag : tagType});
 }
 
-void hasAllTagsChanged(String tag, model.TagStyle tagStyle, TagOperation tagOperation) {
+void hasAllTagsChanged(String tag, model.TagType tagType, TagOperation tagOperation) {
   switch(tagOperation) {
     case TagOperation.ADD:
-      _addTag(tag, tagStyle, model.packageConfigurationData[selectedPackage].hasAllTags);
+      _addTag(tag, tagType, model.packageConfigurationData[selectedPackage].hasAllTags);
       break;
     case TagOperation.UPDATE:
       break;
     case TagOperation.REMOVE:
-      _removeTag(tag, tagStyle, model.packageConfigurationData[selectedPackage].hasAllTags);
+      _removeTag(tag, tagType, model.packageConfigurationData[selectedPackage].hasAllTags);
       break;
   }
   loadPackageConfigurationView();
 }
 
-void containsLastInTurnTagsChanged(String tag, model.TagStyle tagStyle, TagOperation tagOperation) {
+void containsLastInTurnTagsChanged(String tag, model.TagType tagType, TagOperation tagOperation) {
    switch(tagOperation) {
     case TagOperation.ADD:
-      _addTag(tag, tagStyle, model.packageConfigurationData[selectedPackage].containsLastInTurnTags);
+      _addTag(tag, tagType, model.packageConfigurationData[selectedPackage].containsLastInTurnTags);
       break;
     case TagOperation.UPDATE:
       break;
     case TagOperation.REMOVE:
-      _removeTag(tag, tagStyle, model.packageConfigurationData[selectedPackage].containsLastInTurnTags);
+      _removeTag(tag, tagType, model.packageConfigurationData[selectedPackage].containsLastInTurnTags);
       break;
   }
   loadPackageConfigurationView();
 }
 
-void hasNoneTagsChanged(String tag, model.TagStyle tagStyle, TagOperation tagOperation) {
+void hasNoneTagsChanged(String tag, model.TagType tagType, TagOperation tagOperation) {
    switch(tagOperation) {
     case TagOperation.ADD:
-      _addTag(tag, tagStyle, model.packageConfigurationData[selectedPackage].hasNoneTags);
+      _addTag(tag, tagType, model.packageConfigurationData[selectedPackage].hasNoneTags);
       break;
     case TagOperation.UPDATE:
       break;
     case TagOperation.REMOVE:
-      _removeTag(tag, tagStyle, model.packageConfigurationData[selectedPackage].hasNoneTags);
+      _removeTag(tag, tagType, model.packageConfigurationData[selectedPackage].hasNoneTags);
       break;
   }
   loadPackageConfigurationView();
 }
 
-void addsTagsChanged(String originalTag, String updatedTag, model.TagStyle tagStyle, TagOperation tagOperation) {
+void addsTagsChanged(String originalTag, String updatedTag, model.TagType tagType, TagOperation tagOperation) {
   switch(tagOperation) {
     case TagOperation.ADD:
-      _addTag(updatedTag, tagStyle, model.packageConfigurationData[selectedPackage].addsTags, true);
+      _addTag(updatedTag, tagType, model.packageConfigurationData[selectedPackage].addsTags, true);
       break;
     case TagOperation.UPDATE:
       _updateTag(originalTag, updatedTag, model.packageConfigurationData[selectedPackage].addsTags);
       break;
     case TagOperation.REMOVE:
-      _removeTag(originalTag, tagStyle, model.packageConfigurationData[selectedPackage].addsTags, true);
+      _removeTag(originalTag, tagType, model.packageConfigurationData[selectedPackage].addsTags, true);
       break;
   }
   loadPackageConfigurationView();

--- a/webapp/lib/model.dart
+++ b/webapp/lib/model.dart
@@ -108,13 +108,13 @@ List<Map> availablePackages = [
   {'name': 'Bulk Message', 'description': 'Send set of people a once off message', 'details': {'Needs' : 'Definition of who. Safeguarding response', 'Produces' : 'Success/Fail tracker'}},
 ];
 
-Map<String, TagStyle> tags = {
-  'rumour - origin': TagStyle.Normal,
-  'rumour - virus description': TagStyle.Normal,
-  'rumour - cure': TagStyle.Normal,
-  'other tag 1': TagStyle.Normal,
-  'other tag 2': TagStyle.Normal,
-  'other tag 3': TagStyle.Normal
+Map<String, TagType> tags = {
+  'rumour - origin': TagType.Normal,
+  'rumour - virus description': TagType.Normal,
+  'rumour - cure': TagType.Normal,
+  'other tag 1': TagType.Normal,
+  'other tag 2': TagType.Normal,
+  'other tag 3': TagType.Normal
 };
 
 List<Map> changeCommunicationsSuggestedReplies = [
@@ -164,15 +164,15 @@ List<Map> escalatesSuggestedReplies = [
 ];
 
 class Configuration {
-  Map<String, TagStyle> availableTags = {};
-  Map<String, TagStyle> hasAllTags = {};
-  Map<String, TagStyle> containsLastInTurnTags = {};
-  Map<String, TagStyle> hasNoneTags = {};
+  Map<String, TagType> availableTags = {};
+  Map<String, TagType> hasAllTags = {};
+  Map<String, TagType> containsLastInTurnTags = {};
+  Map<String, TagType> hasNoneTags = {};
   List<Map> suggestedReplies = [];
-  Map<String, TagStyle> addsTags = {};
+  Map<String, TagType> addsTags = {};
 }
 
-enum TagStyle {
+enum TagType {
   Normal,
   Important,
 }
@@ -180,16 +180,16 @@ enum TagStyle {
 Map<String, Configuration> packageConfigurationData = {
   'Change communications': new Configuration()
     ..availableTags = tags
-    ..containsLastInTurnTags = {'denial': TagStyle.Normal , 'rumour': TagStyle.Normal}
-    ..hasNoneTags = {'escalate': TagStyle.Normal, 'STOP': TagStyle.Normal}
+    ..containsLastInTurnTags = {'denial': TagType.Normal , 'rumour': TagType.Normal}
+    ..hasNoneTags = {'escalate': TagType.Normal, 'STOP': TagType.Normal}
     ..suggestedReplies = changeCommunicationsSuggestedReplies
-    ..addsTags = {'Organic conversation appreciation': TagStyle.Normal, 'Organic conversation hostility': TagStyle.Normal,
-      'RP Substance appreciation': TagStyle.Normal, 'RP Substance hostility': TagStyle.Normal},
+    ..addsTags = {'Organic conversation appreciation': TagType.Normal, 'Organic conversation hostility': TagType.Normal,
+      'RP Substance appreciation': TagType.Normal, 'RP Substance hostility': TagType.Normal},
   'Urgent conversations': new Configuration()
     ..availableTags = tags
-    ..hasAllTags = {'escalate': TagStyle.Important}
+    ..hasAllTags = {'escalate': TagType.Important}
     ..suggestedReplies = escalatesSuggestedReplies
-    ..addsTags = {'de-escalate': TagStyle.Normal, 'no-escalate': TagStyle.Normal},
+    ..addsTags = {'de-escalate': TagType.Normal, 'no-escalate': TagType.Normal},
   'Open conversations': new Configuration(),
 };
 class User {

--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -634,20 +634,20 @@ class PackageConfiguratorView extends BaseView {
 
   void _buildContentPartial() {
     List<TagView> hasAllTags = [];
-    configurationData.hasAllTags.forEach((tag, tagStyle) {
-      hasAllTags.add(new TagView(tag, tagStyle, controller.hasAllTagsChanged));
+    configurationData.hasAllTags.forEach((tag, tagType) {
+      hasAllTags.add(new TagView(tag, tagType, controller.hasAllTagsChanged));
     });
     var hasAllTagsContainer = new TagListView(hasAllTags, configurationData.availableTags, controller.hasAllTagsChanged).renderElement;
 
     List<TagView> containsLastInTurnTags = [];
-    configurationData.containsLastInTurnTags.forEach((tag, tagStyle) {
-      containsLastInTurnTags.add(new TagView(tag, tagStyle, controller.containsLastInTurnTagsChanged));
+    configurationData.containsLastInTurnTags.forEach((tag, tagType) {
+      containsLastInTurnTags.add(new TagView(tag, tagType, controller.containsLastInTurnTagsChanged));
     });
     var containsLastInTurnTagsContainer = new TagListView(containsLastInTurnTags, configurationData.availableTags, controller.containsLastInTurnTagsChanged).renderElement;
 
     List<TagView> hasNoneTags = [];
-    configurationData.hasNoneTags.forEach((tag, tagStyle) {
-      hasNoneTags.add(new TagView(tag, tagStyle, controller.hasNoneTagsChanged));
+    configurationData.hasNoneTags.forEach((tag, tagType) {
+      hasNoneTags.add(new TagView(tag, tagType, controller.hasNoneTagsChanged));
     });
     var hasNoneTagsContainer = new TagListView(hasNoneTags, configurationData.availableTags, controller.hasNoneTagsChanged).renderElement;
 
@@ -752,8 +752,8 @@ class PackageConfiguratorView extends BaseView {
     );
 
     List<TagView> addsTags = [];
-    configurationData.addsTags.forEach((tag, tagStyle) {
-      addsTags.add(new TagView(tag, tagStyle, controller.addsTagsChanged, true));
+    configurationData.addsTags.forEach((tag, tagType) {
+      addsTags.add(new TagView(tag, tagType, controller.addsTagsChanged, true));
     });
     var addsTagsContainer = new TagListView(addsTags, configurationData.availableTags, controller.addsTagsChanged, true).renderElement;
 
@@ -776,7 +776,7 @@ class TagListView extends BaseView {
   SpanElement _tagsActionContainer;
   Function onTagChangedCallback;
 
-  TagListView(this.tagElements, Map<String, model.TagStyle> availableTags, this.onTagChangedCallback, [bool tagsEditable = false]) {
+  TagListView(this.tagElements, Map<String, model.TagType> availableTags, this.onTagChangedCallback, [bool tagsEditable = false]) {
     _tagsContainer = new DivElement()
       ..classes.add('tags');
     _tagsActionContainer = new SpanElement()
@@ -788,7 +788,7 @@ class TagListView extends BaseView {
           ..onClick.listen((event) {
             event.stopPropagation();
             if (tagsEditable) {
-              var tagElement = new TagView('', model.TagStyle.Normal, onTagChangedCallback, tagsEditable);
+              var tagElement = new TagView('', model.TagType.Normal, onTagChangedCallback, tagsEditable);
               _tagsActionContainer.insertAdjacentElement('beforebegin', tagElement.renderElement);
               tagElement.focus();
               return;
@@ -804,7 +804,7 @@ class TagListView extends BaseView {
 
   DivElement get renderElement => _tagsContainer;
 
-  void _addTagDropdown(Map<String, model.TagStyle> tags, Function onTagChangedCallback) {
+  void _addTagDropdown(Map<String, model.TagType> tags, Function onTagChangedCallback) {
     var tagListDropdown = new Element.ul()
       ..classes.add('add-tag-dropdown');
     var tagsToShow = tags.isEmpty ? ['--None--'] : tags.keys;
@@ -834,19 +834,19 @@ class TagView extends BaseView {
   SpanElement _tagText;
   Function onTagChangedCallback;
 
-  TagView(String tag, model.TagStyle tagStyle, this.onTagChangedCallback, [bool isEditableTag = false]) {
-    _tagElement = _createTag(tag, tagStyle, isEditableTag);
+  TagView(String tag, model.TagType tagType, this.onTagChangedCallback, [bool isEditableTag = false]) {
+    _tagElement = _createTag(tag, tagType, isEditableTag);
   }
 
   DivElement get renderElement => _tagElement;
 
-  DivElement _createTag(String tag, model.TagStyle tagStyle, bool isEditableTag) {
+  DivElement _createTag(String tag, model.TagType tagType, bool isEditableTag) {
     var tagElement = new DivElement()
       ..classes.add('tag')
       ..dataset['id'] = tag.isEmpty ? 'id-123' : tag;
 
-    switch (tagStyle) {
-      case model.TagStyle.Important:
+    switch (tagType) {
+      case model.TagType.Important:
         tagElement.classes.add('tag--important');
         break;
       default:
@@ -866,16 +866,16 @@ class TagView extends BaseView {
           ..text = 'x'
           ..onClick.listen((_) {
             if (isEditableTag) {
-              onTagChangedCallback(tag, tag, tagStyle, controller.TagOperation.REMOVE);
+              onTagChangedCallback(tag, tag, tagType, controller.TagOperation.REMOVE);
               return;
             }
-            onTagChangedCallback(tag, tagStyle, controller.TagOperation.REMOVE);
+            onTagChangedCallback(tag, tagType, controller.TagOperation.REMOVE);
           })
       );
 
     if (isEditableTag) {
       _tagText.contentEditable = 'true';
-      _tagText.onBlur.listen((event) => onTagChangedCallback(tag, (event.target as Element).text, tagStyle, controller.TagOperation.UPDATE));
+      _tagText.onBlur.listen((event) => onTagChangedCallback(tag, (event.target as Element).text, tagType, controller.TagOperation.UPDATE));
     }
 
     return tagElement;


### PR DESCRIPTION
For some reason I can add @ktkization as a review - I suspect it's an org thing. In any case, please take a look.

The marker of what kind of tag is in Nook is called 'TagType' not 'TagStyle' which implies its visual properties, not its meaning. This moves this codebase to be more consistent with Nook.