### PR TITLE
Tag UI improvements

### DIFF
--- a/webapp/lib/view.dart
+++ b/webapp/lib/view.dart
@@ -256,7 +256,6 @@ enum ButtonType {
   remove,
   confirm,
   edit,
-  speech,
 }
 
 class ButtonAction {
@@ -293,9 +292,6 @@ class Button {
         break;
       case ButtonType.edit:
         _element.classes.add('button--edit');
-        break;
-      case ButtonType.speech:
-        _element.classes.add('button--speech');
         break;
     }
   }
@@ -356,19 +352,23 @@ class EditableText {
   DivElement editableWrapper;
 
   Button _editButton;
+  Button _removeButton;
   Button _saveButton;
   Button _cancelButton;
 
   String _textBeforeEdit;
   bool _duringEdit;
 
-  EditableText(Element textElementToEdit, {OnEventCallback onEditStart, OnEventCallback onEditEnd, OnEventCallback onSave}) {
+  EditableText(Element textElementToEdit, {bool alwaysShowButtons: false, OnEventCallback onEditStart, OnEventCallback onEditEnd, OnEventCallback onSave, OnEventCallback onRemove}) {
     editableWrapper = new DivElement()..classes.add('editable-widget');
+    if (alwaysShowButtons)
+      editableWrapper..classes.add('editable-widget--always-show-buttons');
     editableWrapper.append(textElementToEdit);
 
     onEditStart = onEditStart ?? (_) {};
     onEditEnd = onEditEnd ?? (_) {};
     onSave = onSave ?? (_) {};
+    onRemove = onRemove ?? (_) {};
 
     _duringEdit = false;
     var saveEdits = (e) {
@@ -376,6 +376,7 @@ class EditableText {
       _duringEdit = false;
 
       _editButton.parent = editableWrapper;
+      _removeButton.parent = editableWrapper;
       _saveButton.remove();
       _cancelButton.remove();
 
@@ -389,6 +390,7 @@ class EditableText {
       _duringEdit = false;
 
       _editButton.parent = editableWrapper;
+      _removeButton.parent = editableWrapper;
       _saveButton.remove();
       _cancelButton.remove();
 
@@ -401,11 +403,12 @@ class EditableText {
       _duringEdit = true;
 
       _editButton.remove();
+      _removeButton.remove();
       _saveButton.parent = editableWrapper;
       _cancelButton.parent = editableWrapper;
 
       _textBeforeEdit = textElementToEdit.text;
-      _makeEditable(textElementToEdit, onBlur: cancelEdits, onEsc: cancelEdits, onEnter: (e) {
+      _makeEditable(textElementToEdit, onEsc: cancelEdits, onEnter: (e) {
         e.stopPropagation();
         e.preventDefault();
         saveEdits(e);
@@ -417,7 +420,12 @@ class EditableText {
     _editButton = new Button(ButtonType.edit, onClick: startEditing);
     _editButton.parent = editableWrapper;
 
+    _removeButton = new Button(ButtonType.remove, onClick: onRemove);
+    _removeButton.renderElement.classes.add('button--on-hover-red');
+    _removeButton.parent = editableWrapper;
+
     _saveButton = new Button(ButtonType.confirm, onClick: saveEdits);
+    _saveButton.renderElement.classes.add('button--green');
     _cancelButton = new Button(ButtonType.remove, onClick: cancelEdits);
   }
 

--- a/webapp/lib/view_tags.dart
+++ b/webapp/lib/view_tags.dart
@@ -9,7 +9,7 @@ class TagsConfigurationPage extends ConfigurationPage {
   TagsConfigurationPage() : super() {
     _configurationTitle.text = 'How do you want to tag the messages and conversations?';
 
-    _tagsContainer = new DivElement();
+    _tagsContainer = new DivElement()..classes.add('tags-group-list');
     _configurationContent.append(_tagsContainer);
 
     addGroupButton = new Button(ButtonType.add, hoverText: 'Add a new tag group', onClick: (_) => controller.command(controller.UIAction.addTagGroup));

--- a/webapp/web/buttons.css
+++ b/webapp/web/buttons.css
@@ -42,7 +42,7 @@
   top: 1px;
   content: ' ';
   height: 14px;
-  width: 1px;
+  width: 2px;
   background-color: #ccc;
   display: block;
 }
@@ -84,7 +84,7 @@
   top: 1px;
   content: ' ';
   height: 14px;
-  width: 1px;
+  width: 2px;
   background-color: #ccc;
   display: block;
 }
@@ -125,7 +125,7 @@
   top: 1px;
   content: ' ';
   height: 14px;
-  width: 1px;
+  width: 2px;
   background-color: #ccc;
   display: block;
 }
@@ -138,7 +138,7 @@
 
 .button--confirm:after {
   left: 4px;
-  top: -6px;
+  top: -7px;
   height: 7px;
   transform: rotate(310deg);
 }
@@ -167,16 +167,36 @@
   display: block;
 }
 
-/* A baloon button */
-
-.button--speech {
-  width: 16px;
-  height: 16px;
+.button--green:before,
+.button--green:after {
+  background-color: #006400;
+}
+.button--green:hover:before,
+.button--green:hover:after,
+.button--on-hover-green:hover:before,
+.button--on-hover-green:hover:after {
+  background-color: #004b00;
+}
+.button--green:active:before,
+.button--green:active:after,
+.button--on-hover-green:active:before,
+.button--on-hover-green:active:after {
+  background-color: #002d00;
 }
 
-.button--speech:before {
-  content: '💬';
-  display: block;
-  position: relative;
-  top: -4px;
+.button--red:before,
+.button--red:after {
+  background-color: #c00000;
+}
+.button--red:hover:before,
+.button--red:hover:after,
+.button--on-hover-red:hover::before,
+.button--on-hover-red:hover::after {
+  background-color: #a00000;
+}
+.button--red:active:before,
+.button--red:active:after,
+.button--on-hover-red:active:before,
+.button--on-hover-red:active:after {
+  background-color: #990000;
 }

--- a/webapp/web/important.css
+++ b/webapp/web/important.css
@@ -10,8 +10,13 @@
     font-size: .6em;
     font-weight: bold;
     padding-right: 7px;
+    padding-top: 5px;
 }
 
 .foldable.folded::before {
-    content: "►";
+    content: "▷";
+}
+
+.foldable:hover .button {
+    opacity: 0.6;
 }

--- a/webapp/web/styles.css
+++ b/webapp/web/styles.css
@@ -27,5 +27,19 @@ main {
 }
 
 .editable-widget {
-    display: inline-block;
+    display: flex;
+    align-items: center;
+}
+
+.editable-widget .button {
+    opacity: 0;
+}
+
+.editable-widget.editable-widget--always-show-buttons .button {
+    opacity: 0.3;
+}
+
+.editable-widget:hover .button,
+.editable-widget .button:hover {
+    opacity: 1;
 }

--- a/webapp/web/tags.css
+++ b/webapp/web/tags.css
@@ -1,26 +1,24 @@
 @charset "utf-8";
 
+.tags-group-list {
+  border-top: 1px solid #ccc;
+}
+
 .tags-group {
   position: relative;
+  border-bottom: 1px solid #ccc;
 }
 
 .tags-group__title {
   margin: 8px;
   cursor: pointer;
-}
-
-.tags-group__separator {
-  text-align: center;
-  border-bottom: 1px solid #bbb;
-  border-top: 7px solid white;
-  border-left: 32px solid white;
-  border-right: 32px solid white;
+  display: inline-block;
 }
 
 .tags-group__tags {
   display: grid;
   grid-template-columns: repeat(auto-fill, 138px);
-  grid-gap: 4px 10px;
+  grid-gap: 10px 10px;
 }
 
 .tag {

--- a/webapp/web/tags.css
+++ b/webapp/web/tags.css
@@ -12,19 +12,27 @@
 .tags-group__title {
   margin: 8px;
   cursor: pointer;
+  display: flex;
+}
+
+.tags-group__title__text {
   display: inline-block;
 }
 
 .tags-group__tags {
   display: grid;
-  grid-template-columns: repeat(auto-fill, 138px);
+  grid-template-columns: repeat(3, 1fr);
   grid-gap: 10px 10px;
+  margin: 8px;
+  margin-left: 23px;
+  margin-bottom: 12px;
 }
 
 .tag {
   font-size: 12px;
   font-style: italic;
   display: flex;
+  flex-wrap: nowrap;
   position: relative;
 }
 
@@ -87,7 +95,7 @@
 
 .tooltip {
   position: absolute;
-  top: 20px;
+  top: 100%;
   width: 300px;
   height: 300px;
   overflow-y: scroll;


### PR DESCRIPTION
* empty arrows for folded tag groups
* move the remove button to the right of the tag / tag group and make it part of the editable element
* buttons for the tag group appear on hover, and are faded by default for tags
* colour remove button red on hover, and accept change button green
* sample messages on hover rather than separate button
* simplified layout so it's just 3 columns
* other improvements to spacing and alignment